### PR TITLE
Fix a bug with mouseenter not being fired

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ function on (el, event, callback) {
 
 function dynamicStrategy (el, callback) {
   let hasMouseOver = false
-  const enterListener = on(el, 'mouseenter', () => { hasMouseOver = true })
+  const enterListener = on(el, 'mouseover', () => { hasMouseOver = true })
   const leaveListener = on(el, 'mouseleave', () => { hasMouseOver = false })
 
   return {


### PR DESCRIPTION
In some cases when the target element is dynamically shown and the mouse is already over it - the `mouseenter` is not triggered.
`mouseover` is though, so this change fixes the issue.